### PR TITLE
Azure pipelines build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,32 @@
+# azure-storage-cpplite Azure Pipelines Configuration
+
+jobs:
+
+  - job: Ubuntu_16_04
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+      - script: sudo apt-get install libssl-dev libcurl4-openssl-dev cmake g++ uuid-dev
+        displayName: Install dependencies
+
+      - template: azure/cmake-build.yml
+
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: 'build.release/libazure-storage-lite.a'
+          artifactName: ubuntu-drop
+
+  - job: macOS
+    pool:
+      vmImage: 'macOS-10.13'
+    steps:
+      - script: brew install openssl curl-openssl
+        displayName: Brew install dependencies
+
+      - template: azure/cmake-build.yml
+
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: 'build.release/libazure-storage-lite.a'
+          artifactName: macos-drop
+

--- a/azure/cmake-build.yml
+++ b/azure/cmake-build.yml
@@ -1,0 +1,14 @@
+steps:
+- script: |
+    mkdir -p build.release
+  displayName: Make build directories
+
+- task: CMake@1
+  inputs:
+    workingDirectory: 'build.release'
+    cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DUSE_OPENSSL=true'
+
+- script: |
+    cd build.release
+    make -j
+  displayName: 'Run make'


### PR DESCRIPTION
Build definition which could be enabled for CI and PR validation

- Build libazure-storage.so standalone for macOS and Ubuntu
- Publish artifacts

Future todo
* Red Hat build in container
* Windows build
* Testing?

Thoughts on file location in repo? Maybe move both files to a '.azure' folder?