### PR TITLE
API to upload file streams, with known stream length, to blob storage.

### DIFF
--- a/include/blob/blob_client.h
+++ b/include/blob/blob_client.h
@@ -117,8 +117,8 @@ namespace azure { namespace storage_lite {
         /// <param name="blob">The blob name.</param>
         /// <param name="is">The source stream.</param>
         /// <param name="metadata">A <see cref="std::vector"> that respresents metadatas.</param>
-        /// <returns>A <see cref="std::future" /> object that represents the current operation.</returns>
         /// <param name="streamlen">Length of the stream. Used only when the stream does not support tellg/seekg</param>
+        /// <returns>A <see cref="std::future" /> object that represents the current operation.</returns>
         AZURE_STORAGE_API std::future<storage_outcome<void>> upload_block_blob_from_stream(const std::string &container, const std::string &blob, std::istream &is, const std::vector<std::pair<std::string, std::string>> &metadata, size_t streamlen);
 
 
@@ -413,7 +413,7 @@ namespace azure { namespace storage_lite {
         /// <param name="is">The source stream.</param>
         /// <param name="metadata">A <see cref="std::vector"> that respresents metadatas.</param>
         /// <param name="streamlen">Length of the stream. Used only when the stream does not support tellg/seekg</param>
-        void upload_block_blob_from_stream(const std::string &container, const std::string blob, std::istream &is, const std::vector<std::pair<std::string, std::string>> &metadata = std::vector<std::pair<std::string, std::string>>(), size_t streamlen=0);
+        void upload_block_blob_from_stream(const std::string &container, const std::string blob, std::istream &is, const std::vector<std::pair<std::string, std::string>> &metadata = std::vector<std::pair<std::string, std::string>>(), size_t streamlen = NOT_USER_DEFINED_STREAMLEN);
 
         /// <summary>
         /// Uploads the contents of a blob from a local file.
@@ -484,6 +484,7 @@ namespace azure { namespace storage_lite {
         std::mutex s_mutex;
         unsigned int m_concurrency;
         bool m_valid;
+        static const size_t NOT_USER_DEFINED_STREAMLEN = ULLONG_MAX ;
     };
 
 } } // azure::storage_lite

--- a/include/blob/blob_client.h
+++ b/include/blob/blob_client.h
@@ -111,6 +111,18 @@ namespace azure { namespace storage_lite {
         AZURE_STORAGE_API std::future<storage_outcome<void>> upload_block_blob_from_stream(const std::string &container, const std::string &blob, std::istream &is, const std::vector<std::pair<std::string, std::string>> &metadata);
 
         /// <summary>
+        /// Intitiates an asynchronous operation  to upload the contents of a blob from a stream.
+        /// </summary>
+        /// <param name="container">The container name.</param>
+        /// <param name="blob">The blob name.</param>
+        /// <param name="is">The source stream.</param>
+        /// <param name="metadata">A <see cref="std::vector"> that respresents metadatas.</param>
+        /// <returns>A <see cref="std::future" /> object that represents the current operation.</returns>
+        /// <param name="streamlen">Length of the stream. Used only when the stream does not support tellg/seekg</param>
+        AZURE_STORAGE_API std::future<storage_outcome<void>> upload_block_blob_from_stream(const std::string &container, const std::string &blob, std::istream &is, const std::vector<std::pair<std::string, std::string>> &metadata, size_t streamlen);
+
+
+        /// <summary>
         /// Intitiates an asynchronous operation  to delete a blob.
         /// </summary>
         /// <param name="container">The container name.</param>
@@ -400,7 +412,8 @@ namespace azure { namespace storage_lite {
         /// <param name="blob">The blob name.</param>
         /// <param name="is">The source stream.</param>
         /// <param name="metadata">A <see cref="std::vector"> that respresents metadatas.</param>
-        void upload_block_blob_from_stream(const std::string &container, const std::string blob, std::istream &is, const std::vector<std::pair<std::string, std::string>> &metadata = std::vector<std::pair<std::string, std::string>>());
+        /// <param name="streamlen">Length of the stream. Used only when the stream does not support tellg/seekg</param>
+        void upload_block_blob_from_stream(const std::string &container, const std::string blob, std::istream &is, const std::vector<std::pair<std::string, std::string>> &metadata = std::vector<std::pair<std::string, std::string>>(), size_t streamlen=0);
 
         /// <summary>
         /// Uploads the contents of a blob from a local file.

--- a/include/http/libcurl_http_client.h
+++ b/include/http/libcurl_http_client.h
@@ -127,6 +127,26 @@ namespace azure {  namespace storage_lite {
             check_code(curl_easy_setopt(m_curl, CURLOPT_READDATA, this));
         }
 
+        void set_input_stream_length(size_t streamlen)
+        {
+            m_input_stream_len=streamlen;
+        }
+
+        void set_is_stream_length(void)
+        {
+            m_input_stream_len_known=true;
+        }
+
+        bool get_is_stream_length(void)
+        {
+            return m_input_stream_len_known;
+        }
+
+        size_t get_input_stream_length(void)
+        {
+            return m_input_stream_len;
+        }
+
         void reset_input_stream() override
         {
             m_input_stream.reset();
@@ -181,6 +201,8 @@ namespace azure {  namespace storage_lite {
         storage_istream m_input_stream;
         storage_ostream m_output_stream;
         storage_iostream m_error_stream;
+        size_t m_input_stream_len;
+        bool m_input_stream_len_known;
         std::function<bool(http_code)> m_switch_error_callback;
 
         http_code m_code;
@@ -206,14 +228,27 @@ namespace azure {  namespace storage_lite {
         {
             REQUEST_TYPE *p = static_cast<REQUEST_TYPE *>(userdata);
             auto &s = p->m_input_stream.istream();
+            size_t streamlen = p->get_input_stream_length();
+            size_t actual_size = 0 ;
+            if( ! p->get_is_stream_length() ) {
+                auto cur = s.tellg();
+                s.seekg(0, std::ios_base::end);
+                auto end = s.tellg();
+                s.seekg(cur);
+                actual_size = std::min(static_cast<size_t>(end-cur), size * nitems);
+            }
+            else
+            {
+                actual_size = std::min(streamlen, size * nitems);
+            }
 
-            auto cur = s.tellg();
-            s.seekg(0, std::ios_base::end);
-            auto end = s.tellg();
-            s.seekg(cur);
-
-            auto actual_size = std::min(static_cast<size_t>(end - cur), size * nitems);
             s.read(buffer, actual_size);
+
+            if(p->get_is_stream_length()) {
+                streamlen -= actual_size;
+                p->set_input_stream_length(streamlen);
+            }
+
             return actual_size;
         }
 

--- a/include/http/libcurl_http_client.h
+++ b/include/http/libcurl_http_client.h
@@ -132,6 +132,11 @@ namespace azure {  namespace storage_lite {
             m_input_stream_len=streamlen;
         }
 
+        size_t get_input_stream_length(void)
+        {
+            return m_input_stream_len;
+        }
+
         void set_is_stream_length(void)
         {
             m_input_stream_len_known=true;
@@ -140,11 +145,6 @@ namespace azure {  namespace storage_lite {
         bool get_is_stream_length(void)
         {
             return m_input_stream_len_known;
-        }
-
-        size_t get_input_stream_length(void)
-        {
-            return m_input_stream_len;
         }
 
         void reset_input_stream() override

--- a/src/blob/blob_client.cpp
+++ b/src/blob/blob_client.cpp
@@ -119,6 +119,25 @@ std::future<storage_outcome<void>> blob_client::upload_block_blob_from_stream(co
     return async_executor<void>::submit(m_account, request, http, m_context);
 }
 
+std::future<storage_outcome<void>> blob_client::upload_block_blob_from_stream(const std::string &container, const std::string &blob, std::istream &is, const std::vector<std::pair<std::string, std::string>> &metadata, size_t streamlen)
+{
+    auto http = m_client->get_handle();
+
+    auto request = std::make_shared<create_block_blob_request>(container, blob);
+
+    request->set_content_length(streamlen);
+    if (metadata.size() > 0)
+    {
+        request->set_metadata(metadata);
+    }
+
+    http->set_input_stream(storage_istream(is));
+    http->set_is_stream_length();
+    http->set_input_stream_length(streamlen);
+
+    return async_executor<void>::submit(m_account, request, http, m_context);
+}
+
 std::future<storage_outcome<void>> blob_client::delete_blob(const std::string &container, const std::string &blob, bool delete_snapshots)
 {
     auto http = m_client->get_handle();

--- a/src/blob/blob_client_wrapper.cpp
+++ b/src/blob/blob_client_wrapper.cpp
@@ -414,10 +414,10 @@ namespace azure {  namespace storage_lite {
             try
             {
                 AZURE_STORAGE_API std::future<storage_outcome<void>> task;
-                if(streamlen != 0)
-                    task = m_blobClient->upload_block_blob_from_stream(container, blob, is, metadata, streamlen);
-                else
+                if(streamlen == blob_client_wrapper::NOT_USER_DEFINED_STREAMLEN)
                     task = m_blobClient->upload_block_blob_from_stream(container, blob, is, metadata);
+                else
+                    task = m_blobClient->upload_block_blob_from_stream(container, blob, is, metadata, streamlen);
                 auto result = task.get();
                 if(!result.success())
                 {
@@ -433,7 +433,7 @@ namespace azure {  namespace storage_lite {
             }
             catch(std::exception& ex)
             {
-                logger::log(log_level::error, "Unknown failure in upload_block_blob_from_stream.  ex.what() = %s, container = %s, blob = %s Streamlen=%zu.", ex.what(), container.c_str(), blob.c_str(), streamlen);
+                logger::log(log_level::error, "Unknown failure in upload_block_blob_from_stream.  ex.what() = %s, container = %s, blob = %s streamlen=%zu.", ex.what(), container.c_str(), blob.c_str(), streamlen);
                 errno = unknown_error;
             }
         }

--- a/src/blob/blob_client_wrapper.cpp
+++ b/src/blob/blob_client_wrapper.cpp
@@ -398,7 +398,7 @@ namespace azure {  namespace storage_lite {
             }
         }
 
-        void blob_client_wrapper::upload_block_blob_from_stream(const std::string &container, const std::string blob, std::istream &is, const std::vector<std::pair<std::string, std::string>> &metadata)
+        void blob_client_wrapper::upload_block_blob_from_stream(const std::string &container, const std::string blob, std::istream &is, const std::vector<std::pair<std::string, std::string>> &metadata, size_t streamlen)
         {
             if(!is_valid())
             {
@@ -413,7 +413,11 @@ namespace azure {  namespace storage_lite {
 
             try
             {
-                auto task = m_blobClient->upload_block_blob_from_stream(container, blob, is, metadata);
+                AZURE_STORAGE_API std::future<storage_outcome<void>> task;
+                if(streamlen != 0)
+                    task = m_blobClient->upload_block_blob_from_stream(container, blob, is, metadata, streamlen);
+                else
+                    task = m_blobClient->upload_block_blob_from_stream(container, blob, is, metadata);
                 auto result = task.get();
                 if(!result.success())
                 {
@@ -429,7 +433,7 @@ namespace azure {  namespace storage_lite {
             }
             catch(std::exception& ex)
             {
-                logger::log(log_level::error, "Unknown failure in upload_block_blob_from_stream.  ex.what() = %s, container = %s, blob = %s.", ex.what(), container.c_str(), blob.c_str());
+                logger::log(log_level::error, "Unknown failure in upload_block_blob_from_stream.  ex.what() = %s, container = %s, blob = %s Streamlen=%zu.", ex.what(), container.c_str(), blob.c_str(), streamlen);
                 errno = unknown_error;
             }
         }

--- a/src/http/libcurl_http_client.cpp
+++ b/src/http/libcurl_http_client.cpp
@@ -11,6 +11,8 @@ namespace azure {  namespace storage_lite {
             m_curl(h),
             m_slist(NULL)
         {
+            m_input_stream_len=0;
+            m_input_stream_len_known=false;
             check_code(curl_easy_setopt(m_curl, CURLOPT_HEADERFUNCTION, header_callback));
             check_code(curl_easy_setopt(m_curl, CURLOPT_HEADERDATA, this));
         }


### PR DESCRIPTION
Add API to blob client wrapper/blob client to upload file streams, which does not support tellg/seekg to calculate length of the stream, to blob storage.