### PR TITLE
Convenience method to use development storage account

### DIFF
--- a/include/storage_account.h
+++ b/include/storage_account.h
@@ -21,6 +21,8 @@ namespace azure {  namespace storage_lite {
             file
         };
 
+        static std::shared_ptr<storage_account> development_storage_account();
+
         AZURE_STORAGE_API storage_account(const std::string &account_name, std::shared_ptr<storage_credential> credential, bool use_https = true, const std::string &blob_endpoint = std::string());
 
         std::shared_ptr<storage_credential> credential() const

--- a/src/storage_account.cpp
+++ b/src/storage_account.cpp
@@ -4,6 +4,15 @@
 
 namespace azure {  namespace storage_lite {
 
+    std::shared_ptr<storage_account> storage_account::development_storage_account()
+    {
+        std::string account_name = "devstoreaccount1";
+        std::string account_key = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+        std::shared_ptr<storage_credential>  cred = std::make_shared<shared_key_credential>(account_name, account_key);
+        std::shared_ptr<storage_account> account = std::make_shared<storage_account>(account_name, cred, false, "127.0.0.1:10000/devstoreaccount1");
+        return account;
+    }
+
     // TODO: Clean up table queue and file services
     storage_account::storage_account(const std::string &account_name, std::shared_ptr<storage_credential> credential, bool use_https, const std::string &blob_endpoint)
         : m_credential(credential)


### PR DESCRIPTION
- Use known value storage account name, key, endpoint
- Use docker image from https://github.com/Azure/Azurite to validate development storage connection

I was wanting to hook up integration tests in a project I'm using this library for. While I can add the known values to my project, I thought it might be of interest to have a convenience method for this inside the library. The account name and key are set as known values from azure storage emulator documentation.