### PR TITLE
HTTP spec defines header fields as case insensitive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(AZURE_STORAGE_LITE_HEADER
   include/logging.h
   include/base64.h
   include/common.h
+  include/compare.h
   include/constants.h
   include/constants.dat
   include/executor.h

--- a/include/compare.h
+++ b/include/compare.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+
+namespace azure { namespace storage_lite {
+    // Case insensitive comparator for std::map comparator
+    struct case_insensitive_compare 
+    {
+        bool operator()(const std::string &lhs, const std::string &rhs) const 
+        {
+            return strcasecmp(lhs.c_str(), rhs.c_str()) < 0;
+        }
+    };
+}} // azure::storage_lite

--- a/include/http/libcurl_http_client.h
+++ b/include/http/libcurl_http_client.h
@@ -81,7 +81,7 @@ namespace azure {  namespace storage_lite {
                 return "";
             }
         }
-        const std::map<std::string, std::string, CaseInsensitiveCompare>& get_headers() const override
+        const std::map<std::string, std::string, case_insensitive_compare>& get_headers() const override
         {
             return m_headers;
         }
@@ -206,7 +206,7 @@ namespace azure {  namespace storage_lite {
         std::function<bool(http_code)> m_switch_error_callback;
 
         http_code m_code;
-        std::map<std::string, std::string, CaseInsensitiveCompare> m_headers;
+        std::map<std::string, std::string, case_insensitive_compare> m_headers;
 
         AZURE_STORAGE_API static size_t header_callback(char *buffer, size_t size, size_t nitems, void *userdata);
 

--- a/include/http/libcurl_http_client.h
+++ b/include/http/libcurl_http_client.h
@@ -81,7 +81,7 @@ namespace azure {  namespace storage_lite {
                 return "";
             }
         }
-        const std::map<std::string, std::string>& get_headers() const override
+        const std::map<std::string, std::string, CaseInsensitiveCompare>& get_headers() const override
         {
             return m_headers;
         }
@@ -206,7 +206,7 @@ namespace azure {  namespace storage_lite {
         std::function<bool(http_code)> m_switch_error_callback;
 
         http_code m_code;
-        std::map<std::string, std::string> m_headers;
+        std::map<std::string, std::string, CaseInsensitiveCompare> m_headers;
 
         AZURE_STORAGE_API static size_t header_callback(char *buffer, size_t size, size_t nitems, void *userdata);
 

--- a/include/http_base.h
+++ b/include/http_base.h
@@ -10,6 +10,14 @@
 
 namespace azure {  namespace storage_lite {
 
+    // Case insensitive comparator
+    struct CaseInsensitiveCompare 
+    {
+        bool operator()(const std::string &lhs, const std::string &rhs) const {
+            return strcasecmp(lhs.c_str(), rhs.c_str()) < 0;
+        }
+    };
+
     class http_base
     {
     public:
@@ -35,7 +43,7 @@ namespace azure {  namespace storage_lite {
         virtual void add_header(const std::string &name, const std::string &value) = 0;
 
         virtual std::string get_header(const std::string &name) const = 0;
-        virtual const std::map<std::string, std::string>& get_headers() const = 0;
+        virtual const std::map<std::string, std::string, CaseInsensitiveCompare>& get_headers() const = 0;
 
         virtual CURLcode perform() = 0;
 

--- a/include/http_base.h
+++ b/include/http_base.h
@@ -7,16 +7,9 @@
 #include <curl/curl.h>
 
 #include "storage_stream.h"
+#include "compare.h"
 
 namespace azure {  namespace storage_lite {
-
-    // Case insensitive comparator
-    struct CaseInsensitiveCompare 
-    {
-        bool operator()(const std::string &lhs, const std::string &rhs) const {
-            return strcasecmp(lhs.c_str(), rhs.c_str()) < 0;
-        }
-    };
 
     class http_base
     {
@@ -43,7 +36,7 @@ namespace azure {  namespace storage_lite {
         virtual void add_header(const std::string &name, const std::string &value) = 0;
 
         virtual std::string get_header(const std::string &name) const = 0;
-        virtual const std::map<std::string, std::string, CaseInsensitiveCompare>& get_headers() const = 0;
+        virtual const std::map<std::string, std::string, case_insensitive_compare>& get_headers() const = 0;
 
         virtual CURLcode perform() = 0;
 


### PR DESCRIPTION
- https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
- Use std::map with case insensitive compare for keys

Ran into an issue where the https://github.com/Azure/Azurite emulator was returning lower cased header fields and so properties such as content length weren't parsed properly