### PR TITLE
fix on macOS where strcasecmp not declared in scope

### DIFF
--- a/include/compare.h
+++ b/include/compare.h
@@ -3,6 +3,7 @@
 #ifdef __linux__
 #include <string.h>
 #else
+#include <cstring>
 #include <string>
 #endif
 


### PR DESCRIPTION
In tensorflow/io#309 was getting an error of "strcasecmp' was not declared in this scope". 

Seems like we need either string.h or cstring on other platforms other than linux as well