### PR TITLE
Always generate clangd compile_commands.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(azurestoragelite)
 option(BUILD_TESTS "Build test codes" OFF)
 option(BUILD_SAMPLES "Build sample codes" OFF)
 
+# Generate compile_commands.json file
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 set(AZURE_STORAGE_LITE_HEADER
   include/storage_EXPORTS.h
 


### PR DESCRIPTION
cmake can generate compile_commands.json file which is used by language servers such as `clangd`. Setting this to be default on means it will always get generated and so can be used by an editor to provide a better editing experience