### PR TITLE
Add virtual destructors to several base classes

### DIFF
--- a/include/http_base.h
+++ b/include/http_base.h
@@ -23,6 +23,8 @@ namespace azure {  namespace storage_lite {
             put
         };
 
+        virtual ~http_base() {}
+
         using http_code = int;
 
         virtual void set_method(http_method method) = 0;

--- a/include/retry.h
+++ b/include/retry.h
@@ -71,6 +71,7 @@ namespace azure {  namespace storage_lite {
     class retry_policy_base
     {
     public:
+        virtual ~retry_policy_base() {}
         virtual retry_info evaluate(const retry_context &context) const = 0;
     };
 

--- a/include/storage_credential.h
+++ b/include/storage_credential.h
@@ -14,6 +14,7 @@ namespace azure {  namespace storage_lite {
     class storage_credential
     {
     public:
+        virtual ~storage_credential() {};
         virtual void sign_request(const storage_request_base &, http_base &, const storage_url &, const storage_headers &) const {}
         virtual std::string transform_url(std::string url) const
         {

--- a/include/storage_request_base.h
+++ b/include/storage_request_base.h
@@ -11,6 +11,7 @@ namespace azure {  namespace storage_lite {
         {
         public:
             // TODO: create request ID for each request for future debugging purposes.
+            virtual ~storage_request_base() {}
             virtual std::string ms_client_request_id() const { return std::string(); }
 
             virtual void build_request(const storage_account &a, http_base &h) const = 0;

--- a/include/xml_parser_base.h
+++ b/include/xml_parser_base.h
@@ -14,6 +14,8 @@ namespace azure {  namespace storage_lite {
     class xml_parser_base
     {
     public:
+        virtual ~xml_parser_base() {}
+
         virtual storage_error parse_storage_error(const std::string &) const = 0;
 
         template<typename RESPONSE_TYPE>


### PR DESCRIPTION
On Mac OS Mojave (and potentially other platforms), there was a bug
where a lack of virtual destructors would stop make install from
building successfully. This commit adds default virtual destructors to
remedy this problem to several base classes, allowing a destructor to be
called on a pointer to the base class and not produce undefined behavior.