### PR TITLE
fixes for macOS build

### DIFF
--- a/include/blob/append_block_request.h
+++ b/include/blob/append_block_request.h
@@ -4,7 +4,7 @@
 
 namespace azure {  namespace storage_lite {
 
-    class append_block_request : public append_block_request_base 
+    class append_block_request final : public append_block_request_base 
     {
     public:
         append_block_request(const std::string &container, const std::string &blob)

--- a/include/blob/blob_client.h
+++ b/include/blob/blob_client.h
@@ -25,7 +25,7 @@ namespace azure { namespace storage_lite {
     /// Provides a client-side logical representation of blob storage service on Windows Azure. This client is used to configure and execute requests against the service.
     /// </summary>
     /// <remarks>The service client encapsulates the base URI for the service. If the service client will be used for authenticated access, it also encapsulates the credentials for accessing the storage account.</remarks>
-    class blob_client
+    class blob_client final
     {
     public:
         /// <summary>

--- a/include/blob/copy_blob_request.h
+++ b/include/blob/copy_blob_request.h
@@ -4,7 +4,7 @@
 
 namespace azure { namespace storage_lite {
 
-    class copy_blob_request : public copy_blob_request_base 
+    class copy_blob_request final : public copy_blob_request_base 
     {
     public:
         copy_blob_request(const std::string &container, const std::string &blob, const std::string &destContainer, const std::string &destBlob)

--- a/include/blob/create_block_blob_request.h
+++ b/include/blob/create_block_blob_request.h
@@ -58,7 +58,7 @@ namespace azure { namespace storage_lite {
         std::vector<std::pair<std::string, std::string>> m_metadata;
     };
 
-    class create_append_blob_request : public create_block_blob_request
+    class create_append_blob_request final : public create_block_blob_request
     {
     public:
         create_append_blob_request(const std::string &container, const std::string &blob)
@@ -75,7 +75,7 @@ namespace azure { namespace storage_lite {
         }
     };
 
-    class create_page_blob_request : public create_block_blob_request {
+    class create_page_blob_request final : public create_block_blob_request {
     public:
         create_page_blob_request(const std::string &container, const std::string &blob, unsigned long long size)
             : create_block_blob_request(container, blob),

--- a/include/blob/create_container_request.h
+++ b/include/blob/create_container_request.h
@@ -4,7 +4,7 @@
 
 namespace azure { namespace storage_lite {
 
-    class create_container_request : public create_container_request_base
+    class create_container_request final : public create_container_request_base
     {
     public:
         create_container_request(const std::string &container, blob_public_access public_access = blob_public_access::unspecified)

--- a/include/blob/delete_blob_request.h
+++ b/include/blob/delete_blob_request.h
@@ -4,7 +4,7 @@
 
 namespace azure { namespace storage_lite {
 
-    class delete_blob_request : public delete_blob_request_base
+    class delete_blob_request final : public delete_blob_request_base
     {
     public:
         delete_blob_request(const std::string &container, const std::string &blob, bool delete_snapshots_only = false)

--- a/include/blob/delete_container_request.h
+++ b/include/blob/delete_container_request.h
@@ -4,7 +4,7 @@
 
 namespace azure {  namespace storage_lite {
 
-    class delete_container_request : public delete_container_request_base
+    class delete_container_request final : public delete_container_request_base
     {
     public:
         delete_container_request(const std::string &container)

--- a/include/blob/download_blob_request.h
+++ b/include/blob/download_blob_request.h
@@ -4,7 +4,7 @@
 
 namespace azure { namespace storage_lite {
 
-    class download_blob_request : public get_blob_request_base
+    class download_blob_request final : public get_blob_request_base
     {
     public:
         download_blob_request(const std::string &container, const std::string &blob)

--- a/include/blob/get_blob_property_request.h
+++ b/include/blob/get_blob_property_request.h
@@ -4,7 +4,7 @@
 
 namespace azure {  namespace storage_lite {
 
-    class get_blob_property_request : public get_blob_property_request_base
+    class get_blob_property_request final : public get_blob_property_request_base
     {
     public:
         get_blob_property_request(const std::string &container, const std::string &blob)

--- a/include/blob/get_block_list_request.h
+++ b/include/blob/get_block_list_request.h
@@ -4,7 +4,7 @@
 
 namespace azure {  namespace storage_lite {
 
-    class get_block_list_request : public get_block_list_request_base
+    class get_block_list_request final : public get_block_list_request_base
     {
     public:
         get_block_list_request(const std::string &container, const std::string &blob)

--- a/include/blob/get_container_property_request.h
+++ b/include/blob/get_container_property_request.h
@@ -4,7 +4,7 @@
 
 namespace azure {  namespace storage_lite {
 
-    class get_container_property_request : public get_container_property_request_base
+    class get_container_property_request final : public get_container_property_request_base
     {
     public:
         get_container_property_request(const std::string &container)

--- a/include/blob/get_page_ranges_request.h
+++ b/include/blob/get_page_ranges_request.h
@@ -4,7 +4,7 @@
 
 namespace azure {  namespace storage_lite {
 
-    class get_page_ranges_request : public get_page_ranges_request_base
+    class get_page_ranges_request final : public get_page_ranges_request_base
     {
     public:
         get_page_ranges_request(const std::string &container, const std::string &blob)

--- a/include/blob/list_blobs_request.h
+++ b/include/blob/list_blobs_request.h
@@ -4,7 +4,7 @@
 
 namespace azure {  namespace storage_lite {
 
-    class list_blobs_request : public list_blobs_request_base
+    class list_blobs_request final : public list_blobs_request_base
     {
     public:
         list_blobs_request(const std::string &container, const std::string &prefix)
@@ -50,7 +50,7 @@ namespace azure {  namespace storage_lite {
         int m_maxresults;
     };
 
-    class list_blobs_segmented_request : public list_blobs_segmented_request_base
+    class list_blobs_segmented_request final : public list_blobs_segmented_request_base
     {
     public:
         list_blobs_segmented_request(const std::string &container, const std::string &delimiter, const std::string &continuation_token, const std::string &prefix)

--- a/include/blob/list_containers_request.h
+++ b/include/blob/list_containers_request.h
@@ -4,7 +4,7 @@
 
 namespace azure {  namespace storage_lite {
 
-    class list_containers_request : public list_containers_request_base
+    class list_containers_request final : public list_containers_request_base
     {
     public:
         list_containers_request(const std::string &prefix, bool include_metadata = false)

--- a/include/blob/put_block_list_request.h
+++ b/include/blob/put_block_list_request.h
@@ -4,7 +4,7 @@
 
 namespace azure {  namespace storage_lite {
 
-    class put_block_list_request : public put_block_list_request_base
+    class put_block_list_request final : public put_block_list_request_base
     {
     public:
         put_block_list_request(const std::string &container, const std::string &blob)

--- a/include/blob/put_block_request.h
+++ b/include/blob/put_block_request.h
@@ -4,7 +4,7 @@
 
 namespace azure {  namespace storage_lite {
 
-    class put_block_request : public put_block_request_base
+    class put_block_request final : public put_block_request_base
     {
     public:
         put_block_request(const std::string &container, const std::string &blob, const std::string &blockid)

--- a/include/blob/put_page_request.h
+++ b/include/blob/put_page_request.h
@@ -4,7 +4,7 @@
 
 namespace azure {  namespace storage_lite {
 
-    class put_page_request : public put_page_request_base
+    class put_page_request final : public put_page_request_base
     {
     public:
         put_page_request(const std::string &container, const std::string &blob, bool clear = false)

--- a/include/http/libcurl_http_client.h
+++ b/include/http/libcurl_http_client.h
@@ -26,7 +26,7 @@ namespace azure {  namespace storage_lite {
 
     class CurlEasyClient;
 
-    class CurlEasyRequest : public http_base
+    class CurlEasyRequest final : public http_base
     {
 
         using REQUEST_TYPE = CurlEasyRequest;

--- a/include/retry.h
+++ b/include/retry.h
@@ -14,7 +14,7 @@
 
 namespace azure {  namespace storage_lite {
 
-    class retry_info
+    class retry_info final
     {
     public:
         retry_info(bool should_retry, std::chrono::seconds interval)
@@ -36,7 +36,7 @@ namespace azure {  namespace storage_lite {
         std::chrono::seconds m_interval;
     };
 
-    class retry_context
+    class retry_context final
     {
     public:
         retry_context()
@@ -74,7 +74,7 @@ namespace azure {  namespace storage_lite {
         virtual retry_info evaluate(const retry_context &context) const = 0;
     };
 
-    class retry_policy : public retry_policy_base
+    class retry_policy final : public retry_policy_base
     {
     public:
         retry_info evaluate(const retry_context &context) const override

--- a/include/storage_account.h
+++ b/include/storage_account.h
@@ -10,7 +10,7 @@
 
 namespace azure {  namespace storage_lite {
 
-    class storage_account
+    class storage_account final
     {
     public:
         enum class service

--- a/include/storage_credential.h
+++ b/include/storage_credential.h
@@ -21,7 +21,7 @@ namespace azure {  namespace storage_lite {
         }
     };
 
-    class shared_key_credential : public storage_credential
+    class shared_key_credential final : public storage_credential
     {
     public:
         AZURE_STORAGE_API shared_key_credential(const std::string &account_name, const std::string &account_key);
@@ -47,7 +47,7 @@ namespace azure {  namespace storage_lite {
         std::vector<unsigned char> m_account_key;
     };
 
-    class shared_access_signature_credential : public storage_credential
+    class shared_access_signature_credential final : public storage_credential
     {
     public:
         shared_access_signature_credential(const std::string &sas_token)
@@ -67,7 +67,7 @@ namespace azure {  namespace storage_lite {
         std::string m_sas_token;
     };
 
-    class anonymous_credential : public storage_credential
+    class anonymous_credential final : public storage_credential
     {
     public:
         void sign_request(const storage_request_base &, http_base &, const storage_url &, const storage_headers &) const override {}

--- a/include/storage_request_base.h
+++ b/include/storage_request_base.h
@@ -10,6 +10,7 @@ namespace azure {  namespace storage_lite {
         class storage_request_base
         {
         public:
+            virtual ~storage_request_base() = default;
             // TODO: create request ID for each request for future debugging purposes.
             virtual std::string ms_client_request_id() const { return std::string(); }
 

--- a/include/tinyxml2_parser.h
+++ b/include/tinyxml2_parser.h
@@ -9,7 +9,7 @@
 
 namespace azure {  namespace storage_lite {
 
-    class tinyxml2_parser : public xml_parser_base
+    class tinyxml2_parser final : public xml_parser_base
     {
     public:
         AZURE_STORAGE_API storage_error parse_storage_error(const std::string &xml) const override;

--- a/sample/sample.cpp
+++ b/sample/sample.cpp
@@ -28,7 +28,7 @@ int main()
     std::string account_name = "YOUR_ACCOUNT_NAME";
     std::string account_key = "YOUR_ACCOUNT_KEY";
     std::shared_ptr<storage_credential>  cred = std::make_shared<shared_key_credential>(account_name, account_key);
-    std::shared_ptr<storage_account> account = std::make_shared<storage_account>(account_name, cred, false);
+    std::shared_ptr<storage_account> account = std::make_shared<storage_account>(account_name, cred, true);
     auto bC = std::make_shared<blob_client>(account, 10);
     //auto f1 = bc.list_containers("");
     //f1.wait();


### PR DESCRIPTION
Verified by running sample on macOS and linux in docker

Seems utilising c++11 final keyword resolves build issues on macOS.

I had a linking error on macOS and linux for pthread, but will make a separate PR with the CMakeLists.txt change as separate issue to resolve