### PR TITLE
'buff' const-correctness in upload_block_from_buffer()

### DIFF
--- a/include/blob/blob_client.h
+++ b/include/blob/blob_client.h
@@ -241,7 +241,7 @@ namespace azure { namespace storage_lite {
         /// <param name="buffer">The input buffer.</param>
         /// <param name="streamlen">Length of the buffer.</param>
         /// <returns>A <see cref="std::future" /> object that represents the current operation.</returns>
-        AZURE_STORAGE_API std::future<storage_outcome<void>> upload_block_from_buffer(const std::string &container, const std::string &blob, const std::string &blockid, char* buffer, size_t bufferlen);
+        AZURE_STORAGE_API std::future<storage_outcome<void>> upload_block_from_buffer(const std::string &container, const std::string &blob, const std::string &blockid, const char* buffer, size_t bufferlen);
 
         /// <summary>
         /// Intitiates an asynchronous operation  to create a block blob with existing blocks.

--- a/include/http/libcurl_http_client.h
+++ b/include/http/libcurl_http_client.h
@@ -134,7 +134,7 @@ namespace azure {  namespace storage_lite {
             check_code(curl_easy_setopt(m_curl, CURLOPT_READDATA, this));
         }
 
-        void set_input_buffer(char* buff) override
+        void set_input_buffer(const char* buff) override
         {
             m_input_buffer = buff;
             check_code(curl_easy_setopt(m_curl, CURLOPT_READFUNCTION, read));

--- a/include/http_base.h
+++ b/include/http_base.h
@@ -53,7 +53,7 @@ namespace azure {  namespace storage_lite {
 
         virtual void set_input_stream(storage_istream s) = 0;
 
-        virtual void set_input_buffer(char* buff) = 0;
+        virtual void set_input_buffer(const char* buff) = 0;
 
         virtual void reset_input_stream() = 0;
 

--- a/src/blob/blob_client.cpp
+++ b/src/blob/blob_client.cpp
@@ -140,7 +140,7 @@ std::future<storage_outcome<void>> blob_client::upload_block_blob_from_stream(co
     return async_executor<void>::submit(m_account, request, http, m_context);
 }
 
-std::future<storage_outcome<void>> blob_client::upload_block_from_buffer(const std::string &container, const std::string &blob, const std::string &blockid, char* buff, size_t bufferlen)
+std::future<storage_outcome<void>> blob_client::upload_block_from_buffer(const std::string &container, const std::string &blob, const std::string &blockid, const char* buff, size_t bufferlen)
 {
     auto http = m_client->get_handle();
 


### PR DESCRIPTION
The 'buff' argument does not need to be mutable. The const qualfier makes the
interface more flexible because it can now handle const input buffers.