### PR TITLE
Auth support for emulators

### DIFF
--- a/include/storage_credential.h
+++ b/include/storage_credential.h
@@ -26,9 +26,9 @@ namespace azure {  namespace storage_lite {
     class shared_key_credential final : public storage_credential
     {
     public:
-        AZURE_STORAGE_API shared_key_credential(const std::string &account_name, const std::string &account_key);
+        AZURE_STORAGE_API shared_key_credential(const std::string &account_name, const std::string &account_key, bool using_emulator = false);
 
-        AZURE_STORAGE_API shared_key_credential(const std::string &account_name, const std::vector<unsigned char> &account_key);
+        AZURE_STORAGE_API shared_key_credential(const std::string &account_name, const std::vector<unsigned char> &account_key, bool using_emulator = false);
 
         AZURE_STORAGE_API void sign_request(const storage_request_base &r, http_base &h, const storage_url &url, const storage_headers &headers) const override;
 
@@ -47,6 +47,7 @@ namespace azure {  namespace storage_lite {
     private:
         std::string m_account_name;
         std::vector<unsigned char> m_account_key;
+        bool m_using_emulator;
     };
 
     class shared_access_signature_credential final : public storage_credential

--- a/src/storage_account.cpp
+++ b/src/storage_account.cpp
@@ -8,7 +8,7 @@ namespace azure {  namespace storage_lite {
     {
         std::string account_name = "devstoreaccount1";
         std::string account_key = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
-        std::shared_ptr<storage_credential>  cred = std::make_shared<shared_key_credential>(account_name, account_key);
+        std::shared_ptr<storage_credential>  cred = std::make_shared<shared_key_credential>(account_name, account_key, true);
         std::shared_ptr<storage_account> account = std::make_shared<storage_account>(account_name, cred, false, "127.0.0.1:10000/devstoreaccount1");
         return account;
     }


### PR DESCRIPTION
This allows constructing a shared_key_credential that can authenticate
with an emulator (e.g. Azurite)