### PR TITLE
added project name comparison in cmakelists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "
   target_compile_options(azure-storage-lite PRIVATE -Wall -Wextra -Werror -pedantic)
 endif()
 
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_ADLS)
+if(BUILD_ADLS)
   add_subdirectory(adls)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,15 +176,15 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "
   target_compile_options(azure-storage-lite PRIVATE -Wall -Wextra -Werror -pedantic)
 endif()
 
-if(BUILD_ADLS)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_ADLS)
   add_subdirectory(adls)
 endif()
 
-if(BUILD_TESTS)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTS)
   add_subdirectory(test)
 endif()
 
-if(BUILD_SAMPLES)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_SAMPLES)
   add_subdirectory(sample)
 endif()
 


### PR DESCRIPTION
I integrated this repository into my own CMake project(which means I included this repo as a submodule and build it as a subdirectory). I was building my own tests and `azure-storage-cpplite`'s tests are built along with them, which I do not want.

It is recommended to add project name comparison when adding tests in cmake(reference [here](https://cliutils.gitlab.io/modern-cmake/chapters/testing.html)). So I added that.