### PR TITLE
Fix aarch64 build

### DIFF
--- a/adls/include/json.hpp
+++ b/adls/include/json.hpp
@@ -8491,7 +8491,8 @@ scan_number_done:
         std::string result;
         for (const auto c : token_string)
         {
-            if ('\x00' <= c and c <= '\x1F')
+            signed char sc = static_cast<signed char>(c);
+            if ('\x00' <= sc and sc <= '\x1F')
             {
                 // escape control characters
                 std::array<char, 9> cs{{}};


### PR DESCRIPTION
When building on aarch64, the compare of `'\x00'` and a (`unsigned` on aarch64) `char` results in the following error:

```
[ 40%] Building CXX object CMakeFiles/blobfuse.dir/blobfuse/src/BlockBlobBfsClient.cpp.o
In file included from /builder/.cache/yay/azure-storage-fuse/src/azure-storage-fuse-blobfuse-1.4.3/blobfuse/include/OAuthToken.h:7,
                 from /builder/.cache/yay/azure-storage-fuse/src/azure-storage-fuse-blobfuse-1.4.3/blobfuse/include/BlobfuseGlobals.h:9,
                 from /builder/.cache/yay/azure-storage-fuse/src/azure-storage-fuse-blobfuse-1.4.3/blobfuse/src/BlobfuseGcCache.cpp:10:
/builder/.cache/yay/azure-storage-fuse/src/azure-storage-fuse-blobfuse-1.4.3/cpplite/adls/include/json.hpp: In instantiation of 'std::string nlohmann::detail::lexer<BasicJsonType>::get_token_string() const [with BasicJsonType = nlohmann::basic_json<>; std::string = std::__cxx11::basic_string<char>]':
/builder/.cache/yay/azure-storage-fuse/src/azure-storage-fuse-blobfuse-1.4.3/cpplite/adls/include/json.hpp:8745:57:   required from 'void nlohmann::detail::parser<BasicJsonType>::parse(bool, BasicJsonType&) [with BasicJsonType = nlohmann::basic_json<>]'
/builder/.cache/yay/azure-storage-fuse/src/azure-storage-fuse-blobfuse-1.4.3/cpplite/adls/include/json.hpp:20882:79:   required from 'static nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer> nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::parse(IteratorType, IteratorType, nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::parser_callback_t, bool) [with IteratorType = const char*; typename std::enable_if<std::is_base_of<std::random_access_iterator_tag, typename std::iterator_traits<_InputIterator>::iterator_category>::value, int>::type <anonymous> = 0; ObjectType = std::map; ArrayType = std::vector; StringType = std::__cxx11::basic_string<char>; BooleanType = bool; NumberIntegerType = long int; NumberUnsignedType = long unsigned int; NumberFloatType = double; AllocatorType = std::allocator; JSONSerializer = nlohmann::adl_serializer; nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::parser_callback_t = std::function<bool(int, nlohmann::detail::parser<nlohmann::basic_json<> >::parse_event_t, nlohmann::basic_json<>&)>]'
/builder/.cache/yay/azure-storage-fuse/src/azure-storage-fuse-blobfuse-1.4.3/cpplite/adls/include/json.hpp:22700:42:   required from here
/builder/.cache/yay/azure-storage-fuse/src/azure-storage-fuse-blobfuse-1.4.3/cpplite/adls/include/json.hpp:8494:24: error: comparison is always true due to limited range of data type [-Werror=type-limits]
 8494 |             if ('\x00' <= c and c <= '\x1F')
      |                 ~~~~~~~^~~~
```

It could be fixed by casting to `signed char`.